### PR TITLE
Julia benchmark

### DIFF
--- a/monte_carlo_julia.jl
+++ b/monte_carlo_julia.jl
@@ -1,5 +1,4 @@
-
-using Random, Distributions, Statistics
+using Random, Statistics, BenchmarkTools
 
 # Parameters
 S0 = 100
@@ -10,10 +9,10 @@ T = 1
 N = 100000
 
 function monte_carlo_simulation(S0, K, r, σ, T, N)
-    Z = rand(Normal(0, 1), N)
+    Z = randn(N)
     ST = S0 .* exp.((r - 0.5 * σ^2) * T .+ σ * sqrt(T) * Z)
     
-    payoffs = max.(ST .- K, 0)
+    payoffs = max.(ST .- K, 0.)
     option_price = exp(-r * T) * mean(payoffs)
     
     return option_price
@@ -25,3 +24,7 @@ println("European Call Option Price: ", option_price_julia)
 
 # Measure the time for Julia
 @time monte_carlo_simulation(S0, K, r, σ, T, N)
+
+# this version from BenchmarkTools will remove noise from compiling and 
+# referencing global variables in an interactive (e.g. REPL) session
+@btime monte_carlo_simulation($S0, $K, $r, $σ, $T, $N)


### PR DESCRIPTION
I saw your post on LinkedIn about the benchmark and thought I'd try to contribute a couple things:

1. When benchmarking in Julia, to avoid capturing the compile time and use of global variables in the interactive session, use the BenchmarkTools package. The `@time` version seems to be about 30% slower on my laptop than `@btime`
 
2.`randn()` is available in the standard library and you don't need Distributions.jl dependency.

